### PR TITLE
Update binary_sensor_map.rst

### DIFF
--- a/components/sensor/binary_sensor_map.rst
+++ b/components/sensor/binary_sensor_map.rst
@@ -11,7 +11,7 @@ to values. When a given binary sensor is on, the value associated with it in thi
 This sensor is **mostly used for touch** devices but could be used for any ``binary_sensor`` that publishes its ``ON`` or ``OFF`` state.
 
 Add your binary sensors as ``channels`` to the binary sensor map. The binary sensor map then publishes a value depending
-on the type of the binary sensor map and the values specified with each channel.
+on the type of the binary sensor map and the values specified with each channel. The maximum amount of possible channels is 64.
 
 This platform currently supports two measurement types: ``GROUP`` and ``SUM``, and others might get added later.
 You need to specify which type of mapping you want with the ``type:`` configuration value:


### PR DESCRIPTION
Note that the maximum number of channels is 64.

## Description:

The code implicitly has a maximum of 64 total binary_sensor channels. The corresponding PR codifies the max into the sensor.py

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
